### PR TITLE
Update SimpleClearCaseSCM.properties

### DIFF
--- a/src/main/resources/jenkins/plugins/simpleclearcase/SimpleClearCaseSCM.properties
+++ b/src/main/resources/jenkins/plugins/simpleclearcase/SimpleClearCaseSCM.properties
@@ -22,5 +22,5 @@
 # THE SOFTWARE.
 
 TimeZone=CEST
-Locale=SE
+Locale=EN
 FirstFetchMaximumChangelogEntries=50


### PR DESCRIPTION
SCM pooling is not working with SE location if language of jenkins is set to different language from swedish.
Problem was in the date format by the lshistory command.
for example: cleartool setview -exec 'cleartool lshistory -branch -recurse -since 31-borg-17.16:20:06utc+0000 ...'
English is more common all over the word.